### PR TITLE
Allow Partial for Non-Object Hydration

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1845,11 +1845,13 @@ class Parser
      */
     public function PartialObjectExpression()
     {
-        if ($this->query === AbstractQuery::HYDRATE_OBJECT || $this->query === AbstractQuery::HYDRATE_SIMPLEOBJECT) {
+        $hydratationMode = $this->query->getHydrationMode();
+
+        if ($hydratationMode === AbstractQuery::HYDRATE_OBJECT || $hydratationMode === AbstractQuery::HYDRATE_SIMPLEOBJECT) {
             Deprecation::trigger(
                 'doctrine/orm',
                 'https://github.com/doctrine/orm/issues/8471',
-                'PARTIAL syntax for object hydration (mode HYDRATE_OBJECT or HYDRATE_SIMPLEOBJECT) in DQL is deprecated.'
+                'PARTIAL syntax in DQL is deprecated.'
             );
         }
 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1844,11 +1844,13 @@ class Parser
      */
     public function PartialObjectExpression()
     {
-        Deprecation::trigger(
-            'doctrine/orm',
-            'https://github.com/doctrine/orm/issues/8471',
-            'PARTIAL syntax in DQL is deprecated.'
-        );
+        if ($this->query === AbstractQuery::HYDRATE_OBJECT || $this->query === AbstractQuery::HYDRATE_SIMPLEOBJECT) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/issues/8471',
+                'PARTIAL syntax for object hydration (mode HYDRATE_OBJECT or HYDRATE_SIMPLEOBJECT) in DQL is deprecated.'
+            );
+        }
 
         $this->match(Lexer::T_PARTIAL);
 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Query;
 
 use Doctrine\Common\Lexer\Token;
 use Doctrine\Deprecations\Deprecation;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;


### PR DESCRIPTION
As mentioned [here](https://www.doctrine-project.org/projects/doctrine-orm/en/2.16/reference/partial-objects.html) we can understand partial object hydration is a bad idea that can lead to many issues. So it seems a fine to not support it anymore.

But it's also mentionned that the partial object problem does not apply to methods or queries where you do not retrieve the query result as objects. Examples are: Query#getArrayResult(), Query#getScalarResult(), Query#getSingleScalarResult(), etc.

While trying to update code in a project using partial and array result hydration, for performance reasons, my code is way less clean using Dto (that are always flat objects) or using the mix object and scalar data.

Ex. using partial to get an entity with metadata of file attached.
```php
$qb->select('d, p, partial f.{id, mimetype, name, size}')
            ->from(Document::class, 'd')
            ->join('d.file', 'f')
            ->leftJoin('d.publications', 'p')
            ->getQuery()->getArrayResult();
```

Result:
![262074956-2436bfa3-025a-4009-8ee9-eda3ff3b8e81](https://github.com/raziel057/doctrine2/assets/652505/46173fee-d935-46b9-98b9-c0548293e8d6)

Using a Dto, it's not possible to create nested objects like that:
```php
$qb->select('new DocumentDto(d, p, new FileMetadataDto(f.id, f.mimetype, f.name, f.size))')
    ->from(Document::class, 'd')
    ->join('d.file', 'f')
    ->leftJoin('d.publications', 'p')
    ->getQuery()->getArrayResult();
```

I receive an error ``[Syntax Error] line 0, col 53: Error: Unexpected 'new'`` as nested objects are not supported.

Using a flat Dto:
```php
$qb->select('new DocumentDto(d, p, f.id, f.mimetype, f.name, f.size)')
    ->from(Document::class, 'd')
    ->join('d.file', 'f')
    ->leftJoin('d.publications', 'p');
```

I need to type ``publications`` as int rather than ``Collection`` or ``array`` else I receive an error.

```php
use Doctrine\Common\Collections\Collection;

class DocumentDto
{
    public function __construct(
        public int $id,
        public int $publications,
        public int $fileId,
        public string $fileMimetype,
        public string $fileName,
        public int $fileSize,
    ) {
    }
}
```

Result:
![image](https://github.com/raziel057/doctrine2/assets/652505/92a42afe-3e62-4b75-b838-f5ed744e7bd4)

Please note that the objects are duplicated because I have a collection of publication. It's would expect to receive a collection or array of publications here.

Using a mix of object and scalar in query:
```php
$qb->select('d, p, f.id as fileId, f.mimetype as fileMimeType, f.name as fileName, f.size as fileSize')
    ->from(Document::class, 'd')
    ->join('d.file', 'f')
    ->leftJoin('d.publications', 'p');
```

I need to name the scalar fields explicitly to avoid ambiguity when fetching data. I also have a multi level root result which seems not as clean as with partial query.

Result:
![image](https://github.com/raziel057/doctrine2/assets/652505/ef1172c5-3f42-4a1f-8f34-142aea3475fc)

Here is just one of multiple sample I have in mind. Could you please reconsider the support of partial for non problematic use cases? Thanks

Related commit: https://github.com/doctrine/orm/issues/8471